### PR TITLE
Unhardcode linux launcher icon file type

### DIFF
--- a/assets/noisetorch.desktop
+++ b/assets/noisetorch.desktop
@@ -2,7 +2,7 @@
 Name=NoiseTorch
 Comment=Create a virtual microphone that suppresses noise, in any application.
 Exec=noisetorch
-Icon=noisetorch.png
+Icon=noisetorch
 Terminal=false
 Type=Application
 Categories=Audio;AudioVideo;Utility;


### PR DESCRIPTION
Since the icon already is installed to a location compliant with [freedesktop.org standards](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html) you don't need to specify the full icon path or the file type extension in the launcher. 
The icon will be found anyway (without renaming anything).

Cf. this [example `.desktop` launcher](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#example) presented in the freedesktop.org documentation.