### PR TITLE
Add ability to bypass UI

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"image"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -62,8 +61,7 @@ func main() {
 	}
 	defer f.Close()
 
-	logwriter := io.MultiWriter(os.Stdout, f)
-	log.SetOutput(logwriter)
+	log.SetOutput(f)
 	log.Printf("Application starting. Version: %s\n", version)
 
 	initializeConfigIfNot()
@@ -95,13 +93,13 @@ func main() {
 
 	if unload {
 		unloadSupressor(paClient)
-		log.Printf("supressor unloaded\n")
+		fmt.Printf("supressor unloaded\n")
 		os.Exit(0)
 	}
 
 	if sourceName != "" {
 		if supressorState(paClient) != unloaded {
-			log.Printf("supressor is already loaded\n")
+			fmt.Fprintf(os.Stderr, "supressor is already loaded\n")
 			os.Exit(1)
 		}
 
@@ -109,7 +107,7 @@ func main() {
 		for i := range sources {
 			if sources[i].ID == sourceName {
 				loadSupressor(paClient, sources[i], &ui)
-				log.Printf("loaded supressor\n")
+				fmt.Printf("loaded supressor\n")
 				os.Exit(0)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 
 	if unload {
 		unloadSupressor(paClient)
-		log.Printf("supressor unloaded")
+		log.Printf("supressor unloaded\n")
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	logwriter := io.MultiWriter(os.Stdout, f)
 	log.SetOutput(logwriter)
-	log.Printf("Application starting. Version: %s", version)
+	log.Printf("Application starting. Version: %s\n", version)
 
 	initializeConfigIfNot()
 	rnnoisefile := dumpLib()
@@ -95,7 +95,7 @@ func main() {
 		}
 
 		if supressorState(paClient) != unloaded {
-			log.Printf("supressor is already loaded")
+			log.Printf("supressor is already loaded\n")
 			os.Exit(1)
 		}
 
@@ -103,12 +103,12 @@ func main() {
 		for i := range sources {
 			if sources[i].ID == sourceName {
 				loadSupressor(paClient, sources[i], &ui)
-				log.Printf("loaded supressor")
+				log.Printf("loaded supressor\n")
 				os.Exit(0)
 			}
 		}
 
-		log.Printf("PulseAudio source not found: %s", sourceName)
+		log.Printf("PulseAudio source not found: %s\n", sourceName)
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -35,10 +35,12 @@ func main() {
 	var pulsepid int
 	var sourceName string
 	var unload bool
+	var threshold int
 
 	flag.IntVar(&pulsepid, "removerlimit", -1, "for internal use only")
 	flag.StringVar(&sourceName, "s", "", "Load PulseAudio source by name")
 	flag.BoolVar(&unload, "u", false, "Unload supressor")
+	flag.IntVar(&threshold, "t", -1, "voice activation threshold")
 	flag.Parse()
 
 	if pulsepid > 0 {
@@ -68,6 +70,10 @@ func main() {
 	ui := uistate{}
 	ui.config = readConfig()
 	ui.librnnoise = rnnoisefile
+
+	if threshold > 0 {
+		ui.config.Threshold = threshold
+	}
 
 	if unload {
 		paClient, err := pulseaudio.NewClient()

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 			}
 		}
 
-		log.Printf("PulseAudio source not found: %s\n", sourceName)
+		fmt.Fprintf(os.Stderr, "PulseAudio source not found: %s\n", sourceName)
 		os.Exit(1)
 	}
 
@@ -190,6 +190,7 @@ func paConnectionWatchdog(ui *uistate) {
 		paClient, err := pulseaudio.NewClient()
 		if err != nil {
 			log.Printf("Couldn't create pulseaudio client: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Couldn't create pulseaudio client: %v\n", err)
 		}
 
 		ui.paClient = paClient


### PR DESCRIPTION
Added the necessary flags to use Noisetorch without spawning an interface:

* `-u`: Unload a suppressor, if already running
* `-t`: Set voice activation threshold (default 95)
* `-s`: Supply a default PulseAudio source name
* `-l`: List available PulseAudio sources by ID, with source name attached

resolves #37 