### PR TITLE
Use sudo instead of pkexec for CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func main() {
 		sources := getSources(paClient)
 		for i := range sources {
 			if sources[i].ID == sourceName {
-				loadSupressor(paClient, sources[i], &ui)
+				loadSupressor(paClient, sources[i], &ui, true)
 				os.Exit(0)
 			}
 		}

--- a/module.go
+++ b/module.go
@@ -63,7 +63,7 @@ func supressorState(c *pulseaudio.Client) int {
 	return unloaded
 }
 
-func loadSupressor(c *pulseaudio.Client, inp input, ui *uistate) error {
+func loadSupressor(c *pulseaudio.Client, inp input, ui *uistate, usesudo bool) error {
 
 	log.Printf("Querying pulse rlimit\n")
 
@@ -77,7 +77,7 @@ func loadSupressor(c *pulseaudio.Client, inp input, ui *uistate) error {
 		return err
 	}
 	log.Printf("Rlimit: %+v. Trying to remove.\n", lim)
-	removeRlimitAsRoot(pid)
+	removeRlimitAsRoot(pid, usesudo)
 	defer setRlimit(pid, &lim) // lowering RLIMIT doesn't require root
 
 	newLim, err := getRlimit(pid)

--- a/rlimit.go
+++ b/rlimit.go
@@ -43,14 +43,20 @@ func setRlimit(pid int, new *syscall.Rlimit) error {
 	return err
 }
 
-func removeRlimitAsRoot(pid int) {
+func removeRlimitAsRoot(pid int, usesudo bool) {
 	self, err := os.Executable()
 	if err != nil {
 		log.Printf("Couldn't find path to own binary, trying PATH\n")
 		self = "noisetorch" //try PATH and hope for the best
 	}
 
-	cmd := exec.Command("pkexec", self, "-removerlimit", strconv.Itoa(pid))
+	var sudocommand string
+	if usesudo { // use sudo for CLI
+		sudocommand = "sudo"
+	} else { // use pkexec for gui
+		sudocommand = "pkexec"
+	}
+	cmd := exec.Command(sudocommand, self, "-removerlimit", strconv.Itoa(pid))
 	log.Printf("Calling: %s\n", cmd.String())
 	err = cmd.Run()
 	if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -188,7 +188,7 @@ func updatefn(w *nucular.Window, ui *uistate) {
 							log.Println(err)
 						}
 					}
-					if err := loadSupressor(ui.paClient, inp, ui); err != nil {
+					if err := loadSupressor(ui.paClient, inp, ui, false); err != nil {
 						log.Println(err)
 					}
 


### PR DESCRIPTION
This allows for "headless" use in scripts in conjunction with a `NOPASSWD` entry in the sudoers file.

Currently, this always uses `sudo` if called from the CLI, but if you would like sudo usage specified as e.g. a `--sudo` flag, I can do that as well.

I am using this with a systemd user service to start NoiseTorch on login--works great!