### PR TITLE
Load pulse audio default input and store last used input in the config file

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,14 +14,14 @@ type config struct {
 	Threshold             int
 	DisplayMonitorSources bool
 	EnableUpdates         bool
-	LastUsedInput         *string
+	LastUsedInput         string
 }
 
 const configFile = "config.toml"
 
 func initializeConfigIfNot() {
 	log.Println("Checking if config needs to be initialized")
-	conf := config{Threshold: 95, DisplayMonitorSources: false, EnableUpdates: true, LastUsedInput: nil} // if you're a package maintainer and you mess with this, we have a problem.
+	conf := config{Threshold: 95, DisplayMonitorSources: false, EnableUpdates: true, LastUsedInput: ""} // if you're a package maintainer and you mess with this, we have a problem.
 	// Unless you set -tags release on the build the updater is *not* compiled in any. DO NOT MESS WITH THIS!
 	// This isn't and never was the proper location to disable the updater.
 

--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type config struct {
 	Threshold             int
 	DisplayMonitorSources bool
 	EnableUpdates         bool
+	LastUsedInput         *string
 }
 
 const configFile = "config.toml"

--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ const configFile = "config.toml"
 
 func initializeConfigIfNot() {
 	log.Println("Checking if config needs to be initialized")
-	conf := config{Threshold: 95, DisplayMonitorSources: false, EnableUpdates: true} // if you're a package maintainer and you mess with this, we have a problem.
+	conf := config{Threshold: 95, DisplayMonitorSources: false, EnableUpdates: true, LastUsedInput: nil} // if you're a package maintainer and you mess with this, we have a problem.
 	// Unless you set -tags release on the build the updater is *not* compiled in any. DO NOT MESS WITH THIS!
 	// This isn't and never was the proper location to disable the updater.
 

--- a/main.go
+++ b/main.go
@@ -137,7 +137,6 @@ func main() {
 				fmt.Fprintf(os.Stderr, "No source specified to load and failed to load default source: %+v\n", err)
 				os.Exit(1)
 			}
-			fmt.Printf("No source specified to load, loading default source with Device ID %s\n\n", defaultSource)
 			sourceName = defaultSource
 		}
 		for i := range sources {
@@ -235,7 +234,7 @@ func paConnectionWatchdog(ctx *ntcontext) {
 		ctx.paClient = paClient
 		go updateNoiseSupressorLoaded(paClient, &ctx.noiseSupressorState)
 
-		ctx.inputList = getSourcesWithPreSelectedInput(paClient, ctx.config)
+		ctx.inputList = getSourcesWithPreSelectedInput(ctx)
 
 		resetUI(ctx)
 
@@ -243,17 +242,17 @@ func paConnectionWatchdog(ctx *ntcontext) {
 	}
 }
 
-func getSourcesWithPreSelectedInput(client *pulseaudio.Client, config *config) []input {
-	inputs := getSources(client)
-	preselectedInputId := config.LastUsedInput
+func getSourcesWithPreSelectedInput(ctx *ntcontext) []input {
+	inputs := getSources(ctx.paClient)
+	preselectedInputId := ctx.config.LastUsedInput
 	inputExists := false
 	for _, input := range inputs {
 		inputExists = inputExists || input.ID == *preselectedInputId
 	}
 	if !inputExists {
-		defaultSource, err := getDefaultSourceID(client)
+		defaultSource, err := getDefaultSourceID(ctx.paClient)
 		if err != nil {
-			log.Printf("Failed to load default source\n")
+			log.Printf("Failed to load default source: %+v\n", err)
 		} else {
 			preselectedInputId = &defaultSource
 		}

--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ func main() {
 	flag.IntVar(&pulsepid, "removerlimit", -1, "for internal use only")
 	flag.BoolVar(&setcap, "setcap", false, "for internal use only")
 	flag.StringVar(&sourceName, "s", "", "Use the specified source device ID")
-	flag.BoolVar(&load, "i", false, "Load supressor for input")
+	flag.BoolVar(&load, "i", false, "Load supressor for input. If no source device ID is specified the default pulse audio source is used.")
 	flag.BoolVar(&unload, "u", false, "Unload supressor")
 	flag.IntVar(&threshold, "t", -1, "Voice activation threshold")
 	flag.BoolVar(&list, "l", false, "List available PulseAudio sources")

--- a/main.go
+++ b/main.go
@@ -124,17 +124,22 @@ func main() {
 
 	if load {
 		ctx.paClient = paClient
-		if sourceName == "" {
-			fmt.Fprintf(os.Stderr, "No source specified to load.\n")
-			os.Exit(1)
-		}
+		sources := getSources(paClient)
 
 		if supressorState(paClient) != unloaded {
 			fmt.Fprintf(os.Stderr, "Supressor is already loaded.\n")
 			os.Exit(1)
 		}
 
-		sources := getSources(paClient)
+		if sourceName == "" {
+			defaultSource, err := getDefaultSourceID(paClient)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "No source specified to load and failed to load default source: %+v\n", err)
+				os.Exit(1)
+			}
+			fmt.Printf("No source specified to load, loading default source with Device ID %s\n\n", defaultSource)
+			sourceName = defaultSource
+		}
 		for i := range sources {
 			if sources[i].ID == sourceName {
 				err := loadSupressor(&ctx, sources[i])
@@ -145,7 +150,6 @@ func main() {
 				os.Exit(0)
 			}
 		}
-
 		fmt.Fprintf(os.Stderr, "PulseAudio source not found: %s\n", sourceName)
 		os.Exit(1)
 

--- a/main.go
+++ b/main.go
@@ -244,11 +244,11 @@ func paConnectionWatchdog(ctx *ntcontext) {
 
 func getSourcesWithPreSelectedInput(ctx *ntcontext) []input {
 	inputs := getSources(ctx.paClient)
-	preselectedInputId := ctx.config.LastUsedInput
+	preselectedInputID := &ctx.config.LastUsedInput
 	inputExists := false
-	if preselectedInputId != nil {
+	if preselectedInputID != nil {
 		for _, input := range inputs {
-			inputExists = inputExists || input.ID == *preselectedInputId
+			inputExists = inputExists || input.ID == *preselectedInputID
 		}
 	}
 
@@ -257,12 +257,12 @@ func getSourcesWithPreSelectedInput(ctx *ntcontext) []input {
 		if err != nil {
 			log.Printf("Failed to load default source: %+v\n", err)
 		} else {
-			preselectedInputId = &defaultSource
+			preselectedInputID = &defaultSource
 		}
 	}
-	if preselectedInputId != nil {
+	if preselectedInputID != nil {
 		for i := range inputs {
-			if inputs[i].ID == *preselectedInputId {
+			if inputs[i].ID == *preselectedInputID {
 				inputs[i].checked = true
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -246,9 +246,12 @@ func getSourcesWithPreSelectedInput(ctx *ntcontext) []input {
 	inputs := getSources(ctx.paClient)
 	preselectedInputId := ctx.config.LastUsedInput
 	inputExists := false
-	for _, input := range inputs {
-		inputExists = inputExists || input.ID == *preselectedInputId
+	if preselectedInputId != nil {
+		for _, input := range inputs {
+			inputExists = inputExists || input.ID == *preselectedInputId
+		}
 	}
+
 	if !inputExists {
 		defaultSource, err := getDefaultSourceID(ctx.paClient)
 		if err != nil {

--- a/ui.go
+++ b/ui.go
@@ -202,6 +202,8 @@ func updatefn(ctx *ntcontext, w *nucular.Window) {
 							time.Sleep(time.Millisecond * 500)
 						}
 					}
+					ctx.config.LastUsedInput = &inp.ID
+					go writeConfig(ctx.config)
 					ctx.loadingScreen = false
 					(*ctx.masterWindow).Changed()
 				}()

--- a/ui.go
+++ b/ui.go
@@ -202,7 +202,7 @@ func updatefn(ctx *ntcontext, w *nucular.Window) {
 							time.Sleep(time.Millisecond * 500)
 						}
 					}
-					ctx.config.LastUsedInput = &inp.ID
+					ctx.config.LastUsedInput = inp.ID
 					go writeConfig(ctx.config)
 					ctx.loadingScreen = false
 					(*ctx.masterWindow).Changed()


### PR DESCRIPTION
Implementation for https://github.com/lawl/NoiseTorch/issues/66

As per last comment https://github.com/lawl/NoiseTorch/issues/66#issuecomment-740107475

UI

```
Is there a last used device stored in the config?
Y: Try to preselect that
      Available: good, we're done
      Unavailable: preselect pulseaudio default device
N: preselect pulseaudio default device
```

Cli

```
Device passed as parameter?
Y: Try use that, if unavailable, error out.
N: use pulseaudio default device
```


The last used input id is stored in the config when noise torch is loaded

My go knowledge is a bit rusty as I haven't written any line of go in a few years so let me know what can I improve.

Naming is a bit confusing as I don't really have any experience with pulse audio so I'm not sure what the difference between input/source/device, I've tried to keep it consistent but might require some changes.