### PR TITLE
Cli improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 	var loadOutput bool
 	var threshold int
 	var list bool
+	var check bool
 
 	flag.IntVar(&pulsepid, "removerlimit", -1, "for internal use only")
 	flag.BoolVar(&setcap, "setcap", false, "for internal use only")
@@ -58,6 +59,7 @@ func main() {
 	flag.BoolVar(&unload, "u", false, "Unload supressor")
 	flag.IntVar(&threshold, "t", -1, "Voice activation threshold")
 	flag.BoolVar(&list, "l", false, "List available PulseAudio devices")
+	flag.BoolVar(&check, "c", false, "Check supressor status")
 	flag.Parse()
 
 	if setcap {
@@ -107,6 +109,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx.paClient = paClient
+
+	if check {
+		if supressorState(&ctx) == loaded {
+			os.Exit(0)
+		}
+		os.Exit(1)
+	}
+
 	if list {
 		fmt.Println("Sources:")
 		sources := getSources(paClient)
@@ -133,12 +144,15 @@ func main() {
 	}
 
 	if unload {
-		unloadSupressor(&ctx)
+		err := unloadSupressor(&ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error unloading PulseAudio Module: %+v\n", err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 
 	if loadInput {
-		ctx.paClient = paClient
 		sources := getSources(paClient)
 
 		if sinkName == "" {
@@ -165,7 +179,6 @@ func main() {
 
 	}
 	if loadOutput {
-		ctx.paClient = paClient
 		sinks := getSinks(paClient)
 
 		if sinkName == "" {

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	date := time.Now().Format("2006_01_02_03_04_05")
+	date := time.Now().Format("2006_01_02_15_04_05")
 	tmpdir := os.TempDir()
 	f, err := os.OpenFile(filepath.Join(tmpdir, fmt.Sprintf("noisetorch-%s.log", date)), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {


### PR DESCRIPTION
This fixes using the `-u` flag.

Current behavior causes a "connection closed" error when attempting to access the pulseaudio client as `ctx.paClient` is not initialized; the error is also silently ignored.
The `ctx.paClient` is now populated as soon as the client is created and errors are logged.

Added a "check status" `-c` flag, mostly for additional flexibility when scripting (e.g. if not loaded correctly -> reload).

Debatable, but I found the AM/PM notation extremely confusing when trying to read logs, especially because no AM/PM indicator is currently being added to the filename.
The pull request includes switching to 24-hour notation for log file name timestamps.

