### PR TITLE
Fix not printing errror message

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -29,7 +29,7 @@ func doCLI(config *config, librnnoise string) {
 	paClient, err := pulseaudio.NewClient()
 
 	if err != nil {
-		fmt.Printf("Couldn't create pulseaudio client: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Couldn't create pulseaudio client: %v\n", err)
 		os.Exit(1)
 	}
 	defer paClient.Close()

--- a/cli.go
+++ b/cli.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/lawl/pulseaudio"
@@ -30,7 +29,7 @@ func doCLI(config *config, librnnoise string) {
 	paClient, err := pulseaudio.NewClient()
 
 	if err != nil {
-		log.Printf("Couldn't create pulseaudio client: %v\n", err)
+		fmt.Printf("Couldn't create pulseaudio client: %v\n", err)
 		os.Exit(1)
 	}
 	defer paClient.Close()


### PR DESCRIPTION
Error messages were not printed to stderr. Fixed it by using
fmt.Printf() instead of log.Printf().