### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[{go.mod,go.sum,*.go}]
+indent_style = tab
+indent_size = 4
+


### PR DESCRIPTION
This PR adds an EditorConfig, so various text and code editors use the correct settings, without needing to run `gofmt` regularly.

Read more about it [on the website](https://editorconfig.org/).

It is supported in [these code editors](https://editorconfig.org/#pre-installed) and probably more.

