### PR TITLE
Add link to find troubleshooting

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -67,7 +67,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 	w.MenubarBegin()
 
-	w.Row(10).Dynamic(1)
+	w.Row(16).Dynamic(4)
 	if w := w.Menu(label.TA("About", "LC"), 120, nil); w != nil {
 		w.Row(10).Dynamic(1)
 		if w.MenuItem(label.T("Licenses")) {
@@ -80,6 +80,11 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 		if w.MenuItem(label.T("Version")) {
 			ctx.views.Push(versionView)
 		}
+	}
+	w.Label("","RC")
+	w.Label("","RC")
+	if w.Button(label.TA("Troubleshooting", "CC"), true) {
+		exec.Command("xdg-open", "https://github.com/lawl/NoiseTorch/wiki/Troubleshooting").Run()
 	}
 
 	w.MenubarEnd()
@@ -287,12 +292,6 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 		}
 	} else {
 		w.Spacing(1)
-	}
-
-	w.Row(25).Dynamic(4)
-
-	if w.ButtonText("Something is not working...") {
-		exec.Command("xdg-open", "https://github.com/lawl/NoiseTorch/wiki/Troubleshooting").Run()
 	}
 }
 

--- a/ui.go
+++ b/ui.go
@@ -289,6 +289,11 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 		w.Spacing(1)
 	}
 
+	w.Row(25).Dynamic(4)
+
+	if w.ButtonText("Something is not working...") {
+		exec.Command("xdg-open", "https://github.com/lawl/NoiseTorch/wiki/Troubleshooting").Run()
+	}
 }
 
 func uiUnloadNoisetorch(ctx *ntcontext) {


### PR DESCRIPTION
## Description

This PR simply add a button that open the Troubleshooting page of this repo wiki.

When I tried this, I couldn't hear anything in my microphone but I didn't thought about looking for a troubleshooting page. Maybe other people will be as dumb as me and should be helped :=)

The button can be renamed, repositioned, inverted, colored, veganized, I don't have strong feeling about the UI, just that users should know that this page exists somehow.

![image](https://user-images.githubusercontent.com/4447392/146846171-83c528be-0285-46d7-a025-5486ff8174d8.png)