### PR TITLE
Makefile: use $(MAKE) instead of directly using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,4 @@ release: rnnoise
 	go run scripts/signer.go -s
 	git describe --tags > bin/version.txt
 rnnoise:
-	cd c/ladspa; \
-	make
-
+	$(MAKE) -C c/ladspa


### PR DESCRIPTION
While in the process of writing an `ebuild` for Gentoo's [GURU](https://github.com/gentoo/guru/) overlay, the installation raises a warning of the style `warning: jobserver unavailable: using -j1` whose solution [is this one](https://stackoverflow.com/questions/60702726/warning-jobserver-unavailable-using-j1-add-to-parent-make-rule). This is a simple change to implement it.

Thanks for this project!

PS: the information above and the one liner are a courtesy of @thesamesam