### PR TITLE
.desktop file won't work on Fedora

### DIFF
--- a/assets/noisetorch.desktop
+++ b/assets/noisetorch.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
+Version=1.0
 Name=NoiseTorch
 Comment=Create a virtual microphone that suppresses noise, in any application.
 Exec=noisetorch
 Icon=noisetorch
 Terminal=false
 Type=Application
-Categories=Audio;AudioVideo;Utility;
+Categories=Audio;Utility


### PR DESCRIPTION
noisetorch.desktop file won't work on Fedora without the path for the executable in Exec. Exec=.local/bin/noisetorch